### PR TITLE
Fix NPE when mediaFile for Podcast Episode is missing

### DIFF
--- a/subsonic-main/src/main/java/net/sourceforge/subsonic/controller/RESTController.java
+++ b/subsonic-main/src/main/java/net/sourceforge/subsonic/controller/RESTController.java
@@ -1695,6 +1695,10 @@ public class RESTController extends MultiActionController {
         String path = episode.getPath();
         if (path != null) {
             MediaFile mediaFile = mediaFileService.getMediaFile(path);
+            if (mediaFile == null) {
+                LOG.warn("File for PodcastEpisode not found or not readable: " + path);
+                return null;
+            }
             e = createJaxbChild(new org.subsonic.restapi.PodcastEpisode(), player, mediaFile, username);
             e.setStreamId(String.valueOf(mediaFile.getId()));
         }


### PR DESCRIPTION
I have had some Podcasts constantly give a NPE and I was tracked it down to being because the podcast file was missing from the Hard Drive.  No idea how that happened but I know at least a couple others on the forums have had this issue as well.